### PR TITLE
Support RISCV64 vector extension.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 rustflags = ["-C", "target-feature=+neon,+aes"]
 
 [target.'cfg(target_arch="riscv64")']
-rustflags = ["-C", "target-feature=+zkne"]
+rustflags = ["-C", "target-feature=+v,+zvkn"]
 
 [target.'cfg(target_arch="x86_64")']
 rustflags = ["-C", "target-feature=+sse2,+aes"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,14 @@ jobs:
           - name: Linux x86_64
             os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            channel: stable
 
           - name: Linux riscv64gc
             os: ubuntu-24.04
             target: riscv64gc-unknown-linux-gnu
-            channel: nightly
 
           - name: MacOS aarch64
             os: macos-latest
             target: aarch64-apple-darwin
-            channel: stable
 
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -40,8 +37,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install ${{ matrix.channel }} --no-self-update --profile=minimal --component clippy --target ${{ matrix.target }}
-          rustup override set ${{ matrix.channel }}
+          rustup toolchain install stable --no-self-update --profile=minimal --component clippy --target ${{ matrix.target }}
+          rustup override set stable
           cargo -V
 
       - name: Caching
@@ -139,16 +136,13 @@ jobs:
           - name: aarch64
             arch: aarch64
             target: aarch64-unknown-linux-gnu
-            channel: stable
             cpu: a64fx
           - name: riscv64
             arch: riscv64
             target: riscv64gc-unknown-linux-gnu
-            channel: nightly
           - name: x86_64
             arch: x86-64
             target: x86_64-unknown-linux-gnu
-            channel: stable
 
     name: Validate ${{ matrix.name }}
     runs-on: ubuntu-24.04
@@ -165,8 +159,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install ${{ matrix.channel }} --no-self-update --profile=minimal --target ${{ matrix.target }}
-          rustup override set ${{ matrix.channel }}
+          rustup toolchain install stable --no-self-update --profile=minimal --target ${{ matrix.target }}
+          rustup override set stable
           cargo -V
 
       - name: Caching

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ default = ["std", "tls", "getrandom", "rand_core"]
 std = []
 # Activates the thread local functionality.
 tls = ["std"]
+# Enables support for experimental RISC-V vector cryptography extension. Please read the README.md.
+experimental_riscv = []
 
 ### The following features are only used internally and are unstable ###
 # Forces the compiler to always use the fallback (never using the hardware AES directly).

--- a/scripts/run_verification.sh
+++ b/scripts/run_verification.sh
@@ -25,8 +25,8 @@ case $ARCH in
         qemu-aarch64 -cpu cortex-a53 -L /usr/aarch64-linux-gnu ../target/aarch64-unknown-linux-gnu/release/verification
         ;;
     "riscv64")
-        CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc cargo +nightly build --release --target=riscv64gc-unknown-linux-gnu
-        qemu-riscv64 -cpu rv64,zk=true -L /usr/riscv64-linux-gnu ../target/riscv64gc-unknown-linux-gnu/release/verification
+        CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc cargo build --release --target=riscv64gc-unknown-linux-gnu --no-default-features --features=experimental_riscv
+        qemu-riscv64 -cpu rv64,v=true,vlen=128,zvkn=true -L /usr/riscv64-linux-gnu ../target/riscv64gc-unknown-linux-gnu/release/verification
         ;;
     "x86_64")
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc cargo build --release --target=x86_64-unknown-linux-gnu

--- a/src/fallback/mod.rs
+++ b/src/fallback/mod.rs
@@ -5,14 +5,7 @@
 //!     - Fixed: Always uses the software AES implementation.
 #[cfg(all(
     any(
-        not(all(
-            feature = "std",
-            any(
-                target_arch = "aarch64",
-                target_arch = "riscv64",
-                target_arch = "x86_64",
-            )
-        )),
+        not(all(feature = "std", any(target_arch = "aarch64", target_arch = "x86_64",))),
         feature = "force_no_runtime_detection"
     ),
     not(feature = "verification")
@@ -21,14 +14,7 @@ mod fixed;
 
 #[cfg(all(
     not(any(
-        not(all(
-            feature = "std",
-            any(
-                target_arch = "aarch64",
-                target_arch = "riscv64",
-                target_arch = "x86_64",
-            )
-        )),
+        not(all(feature = "std", any(target_arch = "aarch64", target_arch = "x86_64",))),
         feature = "force_no_runtime_detection"
     )),
     not(feature = "verification")
@@ -37,13 +23,9 @@ mod runtime;
 
 pub(crate) mod software;
 
-#[cfg(all( 
+#[cfg(all(
     feature = "std",
-    any(
-        target_arch = "aarch64",
-        target_arch = "riscv64",
-        target_arch = "x86_64",
-    ),
+    any(target_arch = "aarch64", target_arch = "x86_64",),
     not(feature = "force_no_runtime_detection"),
     not(feature = "verification")
 ))]
@@ -51,14 +33,7 @@ pub use runtime::{Aes128Ctr128, Aes128Ctr64, Aes256Ctr128, Aes256Ctr64};
 
 #[cfg(all(
     any(
-        not(all(
-            feature = "std",
-            any(
-                target_arch = "aarch64",
-                target_arch = "riscv64",
-                target_arch = "x86_64",
-            )
-        )),
+        not(all(feature = "std", any(target_arch = "aarch64", target_arch = "x86_64",))),
         feature = "force_no_runtime_detection"
     ),
     not(feature = "verification")

--- a/src/fallback/runtime.rs
+++ b/src/fallback/runtime.rs
@@ -23,10 +23,6 @@ pub(crate) fn has_hardware_acceleration() -> bool {
     {
         return true;
     }
-    #[cfg(target_arch = "riscv64")]
-    if std::arch::is_riscv_feature_detected!("zkne") {
-        return true;
-    }
 
     false
 }
@@ -265,9 +261,7 @@ impl Aes256Ctr64 {
                 // Safety: We checked that the hardware acceleration is available.
                 unsafe { this.next_impl() }
             }
-            Aes256Ctr64Inner::Software(this) => {
-                this.borrow_mut().next_impl()
-            },
+            Aes256Ctr64Inner::Software(this) => this.borrow_mut().next_impl(),
         }
     }
 }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -21,9 +21,7 @@ pub use x86_64::{Aes128Ctr128, Aes128Ctr64, Aes256Ctr128, Aes256Ctr64};
                 target_feature = "sse2",
                 target_feature = "aes",
             ),
-            all(
-                target_arch = "riscv64", target_feature = "zkne"
-            ),
+            all(target_arch = "riscv64", feature = "experimental_riscv"),
             all(
                 target_arch = "aarch64",
                 target_feature = "neon",

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -12,7 +12,7 @@ macro_rules! safely_call {
                     target_feature = "sse2",
                     target_feature = "aes",
                 ),
-                all(target_arch = "riscv64", target_feature = "zkne"),
+                all(target_arch = "riscv64", feature = "experimental_riscv"),
                 all(
                     target_arch = "aarch64",
                     target_feature = "neon",
@@ -32,7 +32,7 @@ macro_rules! safely_call {
                     target_feature = "sse2",
                     target_feature = "aes",
                 ),
-                all(target_arch = "riscv64", target_feature = "zkne"),
+                all(target_arch = "riscv64", feature = "experimental_riscv"),
                 all(
                     target_arch = "aarch64",
                     target_feature = "neon",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,16 +23,19 @@
 //! Use the following target features for optimal performance:
 //!
 //! - aarch64: `aes` (using the cryptographic extension)
-//! - riscv64: `zkne` (using the scalar based cryptography extension)
 //! - x86_64: `aes` (using AES-NI)
+//!
+//! There is experimental support for the RISC-V vector crypto extension. Please read the README.md
+//! for more information how to use it.
 //!
 //! ## Security Note
 //!
-//! While based on well-established cryptographic primitives, this PRNG is not intended for cryptographic key generation
-//! or other sensitive cryptographic operations, simply because safe, automatic re-seeding is not provided. We tested its
-//! statistical qualities by running versions with reduced rounds against `practrand` and `TESTu01`'s Big Crush.
-//! A version with just 3 rounds of AES encryption rounds passes the `practrand` tests with at least 16 TB.
-//! `TESTu01`'s Big Crush requires at least 5 rounds to be successfully cleared. AES-128 uses 10 rounds, whereas
+//! While based on well-established cryptographic primitives, this PRNG is not intended for
+//! cryptographic key generation or other sensitive cryptographic operations, simply because safe,
+//! automatic re-seeding is not provided. We tested its statistical qualities by running versions
+//! with reduced rounds against `practrand` and `TESTu01`'s Big Crush. A version with just 3 rounds
+//! of AES encryption rounds passes the `practrand` tests with at least 16 TB. `TESTu01`'s Big Crush
+//! requires at least 5 rounds to be successfully cleared. AES-128 uses 10 rounds, whereas
 //! AES-256 uses 14 rounds.
 //!
 //! ## Parallel Stream Generation
@@ -58,7 +61,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "verification", allow(unused))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(target_arch = "riscv64", feature(riscv_ext_intrinsics))]
 
 pub mod seeds;
 
@@ -75,9 +77,7 @@ mod traits;
             target_feature = "sse2",
             target_feature = "aes",
         ),
-        all(
-            target_arch = "riscv64", target_feature = "zkne"
-        ),
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
         all(
             target_arch = "aarch64",
             target_feature = "neon",
@@ -97,9 +97,7 @@ pub(crate) mod fallback;
                 target_feature = "sse2",
                 target_feature = "aes",
             ),
-            all(
-                target_arch = "riscv64", target_feature = "zkne"
-            ),
+            all(target_arch = "riscv64", feature = "experimental_riscv"),
             all(
                 target_arch = "aarch64",
                 target_feature = "neon",
@@ -119,9 +117,7 @@ pub use fallback::{Aes128Ctr128, Aes128Ctr64, Aes256Ctr128, Aes256Ctr64};
             target_feature = "sse2",
             target_feature = "aes",
         ),
-        all(
-            target_arch = "riscv64", target_feature = "zkne"
-        ),
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
         all(
             target_arch = "aarch64",
             target_feature = "neon",
@@ -142,9 +138,7 @@ pub use hardware::{Aes128Ctr128, Aes128Ctr64, Aes256Ctr128, Aes256Ctr64};
                     target_feature = "sse2",
                     target_feature = "aes",
                 ),
-                all(
-                    target_arch = "riscv64", target_feature = "zkne"
-                ),
+                all(target_arch = "riscv64", feature = "experimental_riscv"),
                 all(
                     target_arch = "aarch64",
                     target_feature = "neon",

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -17,7 +17,7 @@ use crate::Random;
             target_feature = "sse2",
             target_feature = "aes",
         ),
-        all(target_arch = "riscv64", target_feature = "zkne"),
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
         all(
             target_arch = "aarch64",
             target_feature = "neon",
@@ -37,7 +37,7 @@ thread_local! {
             target_feature = "sse2",
             target_feature = "aes",
         ),
-        all(target_arch = "riscv64", target_feature = "zkne"),
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
         all(
             target_arch = "aarch64",
             target_feature = "neon",

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -60,7 +60,9 @@ fn verify_aes128_ctr64(key: [u8; AES128_KEY_SIZE], iv: [u8; AES_BLOCK_SIZE]) {
     let hardware = unsafe { Aes128Ctr64Hardware::from_seed_impl(key, nonce, ctr) };
 
     for _ in 0..u8::MAX {
-        assert_eq!(software.next_impl(), unsafe { hardware.next_impl() });
+        assert_eq!(software.next_impl().to_le_bytes(), unsafe {
+            hardware.next_impl().to_le_bytes()
+        });
     }
 }
 
@@ -69,7 +71,9 @@ fn verify_aes128_ctr128(key: [u8; AES128_KEY_SIZE], iv: [u8; AES_BLOCK_SIZE]) {
     let hardware = unsafe { Aes128Ctr128Hardware::from_seed_impl(key, iv) };
 
     for _ in 0..u8::MAX {
-        assert_eq!(software.next_impl(), unsafe { hardware.next_impl() });
+        assert_eq!(software.next_impl().to_le_bytes(), unsafe {
+            hardware.next_impl().to_le_bytes()
+        });
     }
 }
 
@@ -83,7 +87,9 @@ fn verify_aes256_ctr64(key: [u8; AES256_KEY_SIZE], iv: [u8; AES_BLOCK_SIZE]) {
     let hardware = unsafe { Aes256Ctr64Hardware::from_seed_impl(key, nonce, ctr) };
 
     for _ in 0..u8::MAX {
-        assert_eq!(software.next_impl(), unsafe { hardware.next_impl() });
+        assert_eq!(software.next_impl().to_le_bytes(), unsafe {
+            hardware.next_impl().to_le_bytes()
+        });
     }
 }
 
@@ -92,6 +98,8 @@ fn verify_aes256_ctr128(key: [u8; AES256_KEY_SIZE], iv: [u8; AES_BLOCK_SIZE]) {
     let hardware = unsafe { Aes256Ctr128Hardware::from_seed_impl(key, iv) };
 
     for _ in 0..u8::MAX {
-        assert_eq!(software.next_impl(), unsafe { hardware.next_impl() });
+        assert_eq!(software.next_impl().to_le_bytes(), unsafe {
+            hardware.next_impl().to_le_bytes()
+        });
     }
 }

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+experimental_riscv = ["rand_aes/experimental_riscv"]
+force_fallback = ["rand_aes/force_fallback"]
+force_no_runtime_detection = ["rand_aes/force_no_runtime_detection"]
+
 [dependencies]
-rand_aes =  { path = "..", features = ["verification"] }
+rand_aes = { path = "..", features = ["verification"] }
 
 [[bin]]
 name = "verification"

--- a/verification/src/bin/verification.rs
+++ b/verification/src/bin/verification.rs
@@ -1,9 +1,7 @@
 fn main() {
     println!("Starting verification");
 
-    unsafe {
-        rand_aes::verification::run_verification()
-    };
+    unsafe { rand_aes::verification::run_verification() };
 
     println!("Passed verification!");
 }


### PR DESCRIPTION
This PR removes the old scalar crypto RISC-V backend and adds a vector crypto based backend instead. Both extensions have no real world implementations, but since application class CPUs will have the vector extension implemented, I have a feeling that vector crypto support will be dominating (since it's efficienter). There is currently no runtime detection support available.

The implementation is written with inline ASM and is supported by the latest stable version (1.80).

I moved the support behind a experimental feature. Implementd #2 