### PR TITLE
Fix compiling to other platforms and add WASM to CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
             target: aarch64-apple-darwin
             arguments: ""
 
+          - name: Plain Wasm32 (JavaScript Host for getrandom)
+            os: ubuntu-24.04
+            target: wasm32-unknown-unknown
+            arguments: "--features getrandom/js"
     name: Clippy ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -80,8 +84,14 @@ jobs:
             os: macos-latest
             target: aarch64-apple-darwin
 
+          - name: Wasm32 Wasip1
+            os: ubuntu-24.04
+            target: wasm32-wasip1
+
     name: Test ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
     needs: [ check ]
 
     steps:
@@ -90,7 +100,7 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup toolchain install stable --no-self-update --profile=minimal --target ${{ matrix.target }}
           cargo -V
 
       - name: Caching
@@ -98,35 +108,40 @@ jobs:
         with:
           key: test-${{ matrix.target }}
 
+      - name: Setup `wasmtime`
+        if: matrix.target == 'wasm32-wasip1'
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
       - name: Tests (default)
         shell: bash
         run: |
           set -e
-          cargo test --lib --tests
+          cargo test --lib --tests --target ${{ matrix.target }}
 
       - name: Tests (force_software)
         shell: bash
         run: |
           set -e
-          cargo test --lib --tests --features=force_software
+          cargo test --lib --tests --features=force_software --target ${{ matrix.target }}
 
       - name: Tests (force_runtime_detection)
+        if: matrix.target != 'wasm32-wasip1'
         shell: bash
         run: |
           set -e
-          cargo test --lib --tests --features=force_runtime_detection
+          cargo test --lib --tests --features=force_runtime_detection --target ${{ matrix.target }}
 
       - name: Tests no-std
         shell: bash
         run: |
           set -e
-          cargo test --lib --tests --no-default-features
+          cargo test --lib --tests --no-default-features --target ${{ matrix.target }}
 
       - name: Tests no-std (force_software)
         shell: bash
         run: |
           set -e
-          cargo test --lib --tests --no-default-features --features=force_software
+          cargo test --lib --tests --no-default-features --features=force_software --target ${{ matrix.target }}
 
   verification:
     timeout-minutes: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,14 @@ rand_core = { version = "0.6", optional = true }
 getrandom = { version = "0.2", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 hex-literal = "0.4"
 paste = "1"
 rand_chacha = "0.3"
 rand_pcg = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [profile.bench]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,27 @@ mod traits;
 mod backend;
 
 #[cfg(all(
+    feature = "force_runtime_detection",
+    not(any(
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        target_arch = "x86",
+    ))
+))]
+compile_error!("The hardware AES implementation is not available for this platform. Remove the `force_runtime_detection` feature");
+
+#[cfg(all(feature = "force_runtime_detection", not(feature = "std")))]
+compile_error!("The runtime detection is not supported in `no_std`");
+
+#[cfg(all(
     feature = "std",
-    not(target_arch = "riscv64"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "x86",
+        target_arch = "aarch64",
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
+    ),
     any(
         not(any(
             all(
@@ -88,6 +107,7 @@ mod backend;
                 target_feature = "neon",
                 target_feature = "aes",
             ),
+            all(target_arch = "riscv64", feature = "experimental_riscv"),
         )),
         feature = "force_runtime_detection",
     ),
@@ -96,7 +116,12 @@ pub(crate) mod runtime;
 
 #[cfg(all(
     feature = "std",
-    not(target_arch = "riscv64"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "x86",
+        target_arch = "aarch64",
+        all(target_arch = "riscv64", feature = "experimental_riscv"),
+    ),
     any(
         not(any(
             all(
@@ -109,6 +134,7 @@ pub(crate) mod runtime;
                 target_feature = "neon",
                 target_feature = "aes",
             ),
+            all(target_arch = "riscv64", feature = "experimental_riscv"),
         )),
         feature = "force_runtime_detection",
     ),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -54,6 +54,14 @@ pub struct Aes128Ctr64(Aes128Ctr64Inner);
 
 impl Aes128Ctr64 {
     // This function is needed for the TLS.
+    #[cfg(all(
+        feature = "tls",
+        not(any(
+            feature = "tls_aes128_ctr128",
+            feature = "tls_aes256_ctr64",
+            feature = "tls_aes256_ctr128"
+        ))
+    ))]
     pub(crate) fn zeroed() -> Self {
         match has_hardware_acceleration() {
             true => {


### PR DESCRIPTION
This PR does 3 things:
1. Fix cfgs such that other architectures will get the software implementation correctly.
2. Fix the cfgs such that the force_runtime_detection works without enabling the TLS feature
3. add plain `wasm32-unknown-unknown` to clippy CI and `wasm32-wasip1` to test CI

Related: https://github.com/hasenbanck/rand_aes/issues/9