### PR TITLE
Bump rand_core to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,14 @@ verification = ["std"]
 
 [dependencies]
 # Implements the `CoreRng` and `SeedableRng` traits.
-rand_core = { version = "0.9", optional = true }
+rand_core = { version = "0.10", optional = true }
 # Provides seeding from the OS entropy source.
 getrandom = { version = "0.3", optional = true }
 
 [dev-dependencies]
 hex-literal = "1.0"
-rand_chacha = "0.9"
-rand_pcg = "0.9"
+rand_chacha = "0.10"
+rand_pcg = "0.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { version = "0.7", features = ["cargo_bench_support", "html_reports"] }

--- a/benches/benchmark_rng.rs
+++ b/benches/benchmark_rng.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use rand_aes::tls::{rand_fill_bytes, rand_seed_from_entropy, rand_u64};
 use rand_aes::{Aes128Ctr128, Aes128Ctr64, Aes256Ctr128, Aes256Ctr64};
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -297,77 +297,89 @@ impl Jump for Aes256Ctr128 {
 
 #[cfg(feature = "rand_core")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl rand_core::RngCore for Aes128Ctr64 {
+impl rand_core::TryRng for Aes128Ctr64 {
+    type Error = rand_core::Infallible;
+
     #[inline(always)]
-    fn next_u32(&mut self) -> u32 {
-        safely_call! { self.next_impl() as u32 }
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u32) }
     }
 
     #[inline(always)]
-    fn next_u64(&mut self) -> u64 {
-        safely_call! { self.next_impl() as u64 }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u64) }
     }
 
     #[inline(always)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Random::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
 #[cfg(feature = "rand_core")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl rand_core::RngCore for Aes128Ctr128 {
+impl rand_core::TryRng for Aes128Ctr128 {
+    type Error = rand_core::Infallible;
+
     #[inline(always)]
-    fn next_u32(&mut self) -> u32 {
-        safely_call! { self.next_impl() as u32 }
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u32) }
     }
 
     #[inline(always)]
-    fn next_u64(&mut self) -> u64 {
-        safely_call! { self.next_impl() as u64 }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u64) }
     }
 
     #[inline(always)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Random::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
 #[cfg(feature = "rand_core")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl rand_core::RngCore for Aes256Ctr64 {
+impl rand_core::TryRng for Aes256Ctr64 {
+    type Error = rand_core::Infallible;
+
     #[inline(always)]
-    fn next_u32(&mut self) -> u32 {
-        safely_call! { self.next_impl() as u32 }
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u32) }
     }
 
     #[inline(always)]
-    fn next_u64(&mut self) -> u64 {
-        safely_call! { self.next_impl() as u64 }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u64) }
     }
 
     #[inline(always)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Random::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
 #[cfg(feature = "rand_core")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-impl rand_core::RngCore for Aes256Ctr128 {
+impl rand_core::TryRng for Aes256Ctr128 {
+    type Error = rand_core::Infallible;
+
     #[inline(always)]
-    fn next_u32(&mut self) -> u32 {
-        safely_call! { self.next_impl() as u32 }
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u32) }
     }
 
     #[inline(always)]
-    fn next_u64(&mut self) -> u64 {
-        safely_call! { self.next_impl() as u64 }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        safely_call! { Ok(self.next_impl() as u64) }
     }
 
     #[inline(always)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         Random::fill_bytes(self, dest);
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!  4. [`Aes256Ctr128`]: Utilizes AES-256 encryption with a 128-bit counter.
 //!
 //! Common functionality is provided using the [`Random`] trait or the optionally provided
-//! [`rand_core::RngCore`] and [`rand_core::SeedableRng`] traits.
+//! [`rand_core::Rng`] and [`rand_core::SeedableRng`] traits.
 //!
 //! ## Optimal Performance
 //!


### PR DESCRIPTION
Hey!
I want to use your library with rand-core version 0.10.
So in the spirit of open-source I created this PR.
I `cargo test` and `cargo bench` the repo, and there werent any errors.

Because its a repo which is about cryptography I urge you to make all the appropriate checks.

If any changes needed, let me know.